### PR TITLE
Update docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.2
+FROM golang:1.7.3
 
 RUN apt-get update && apt-get install -y \
     iptables build-essential \

--- a/create.go
+++ b/create.go
@@ -6,9 +6,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/container"
-	"github.com/docker/engine-api/types/strslice"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/strslice"
 )
 
 // Create lets you create a container with the specified image, and default

--- a/docker.go
+++ b/docker.go
@@ -7,7 +7,7 @@ package docker
 
 import (
 	"fmt"
-	"github.com/docker/engine-api/client"
+	"github.com/docker/docker/client"
 )
 
 const (

--- a/image.go
+++ b/image.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
 // Pull pulls the given reference (image)
@@ -18,7 +18,7 @@ func (p *Project) Pull(ref string) error {
 func (p *Project) ensureImageExists(ref string, force bool) error {
 	if !force {
 		// Check if ref is already there
-		_, _, err := p.Client.ImageInspectWithRaw(context.Background(), ref, false)
+		_, _, err := p.Client.ImageInspectWithRaw(context.Background(), ref)
 		if err != nil && !client.IsErrImageNotFound(err) {
 			return err
 		}

--- a/inspect.go
+++ b/inspect.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
 )
 
 // Inspect returns the container informations

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -5,10 +5,10 @@ import (
 
 	"golang.org/x/net/context"
 
-	dockerclient "github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
+	dockerclient "github.com/docker/docker/client"
 	// "github.com/docker/engine-api/types/container"
-	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/libkermit/docker"
 )
 

--- a/integration/testing/helper_test.go
+++ b/integration/testing/helper_test.go
@@ -5,9 +5,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	dockerclient "github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	dockerclient "github.com/docker/docker/client"
 	d "github.com/libkermit/docker"
 	docker "github.com/libkermit/docker/testing"
 )

--- a/list.go
+++ b/list.go
@@ -5,8 +5,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 )
 
 // List lists the containers managed by kermit

--- a/remove.go
+++ b/remove.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
 )
 
 // Remove removes the container

--- a/start.go
+++ b/start.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
 )
 
 // Start lets you create and start a container with the specified image, and

--- a/test/nop.go
+++ b/test/nop.go
@@ -7,11 +7,11 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/container"
-	"github.com/docker/engine-api/types/filters"
-	"github.com/docker/engine-api/types/network"
-	"github.com/docker/engine-api/types/registry"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/registry"
 )
 
 var (
@@ -138,8 +138,8 @@ func (client *NopClient) ContainerStatPath(ctx context.Context, container, path 
 }
 
 // ContainerStats returns near realtime stats for a given container
-func (client *NopClient) ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error) {
-	return nil, errNoEngine
+func (client *NopClient) ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error) {
+	return types.ContainerStats{}, errNoEngine
 }
 
 // ContainerStart sends a request to the docker daemon to start a container
@@ -163,8 +163,8 @@ func (client *NopClient) ContainerUnpause(ctx context.Context, container string)
 }
 
 // ContainerUpdate updates resources of a container
-func (client *NopClient) ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error {
-	return errNoEngine
+func (client *NopClient) ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (types.ContainerUpdateResponse, error) {
+	return types.ContainerUpdateResponse{}, errNoEngine
 }
 
 // ContainerWait pauses execution until a container exits
@@ -180,6 +180,11 @@ func (client *NopClient) CopyFromContainer(ctx context.Context, container, srcPa
 // CopyToContainer copies content into the container filesystem
 func (client *NopClient) CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
 	return errNoEngine
+}
+
+// ContainersPrune requests the daemon to delete unused data
+func (client *NopClient) ContainersPrune(ctx context.Context, cfg types.ContainersPruneConfig) (types.ContainersPruneReport, error) {
+	return types.ContainersPruneReport{}, errNoEngine
 }
 
 // Events returns a stream of events in the daemon in a ReadCloser
@@ -208,12 +213,12 @@ func (client *NopClient) ImageImport(ctx context.Context, source types.ImageImpo
 }
 
 // ImageInspectWithRaw returns the image information and it's raw representation
-func (client *NopClient) ImageInspectWithRaw(ctx context.Context, image string, getSize bool) (types.ImageInspect, []byte, error) {
+func (client *NopClient) ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error) {
 	return types.ImageInspect{}, nil, errNoEngine
 }
 
 // ImageList returns a list of images in the docker host
-func (client *NopClient) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.Image, error) {
+func (client *NopClient) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error) {
 	return nil, errNoEngine
 }
 
@@ -250,6 +255,11 @@ func (client *NopClient) ImageSave(ctx context.Context, images []string) (io.Rea
 // ImageTag tags an image in the docker host
 func (client *NopClient) ImageTag(ctx context.Context, image, ref string) error {
 	return errNoEngine
+}
+
+// ImagesPrune requests the daemon to delete unused data
+func (client *NopClient) ImagesPrune(ctx context.Context, cfg types.ImagesPruneConfig) (types.ImagesPruneReport, error) {
+	return types.ImagesPruneReport{}, errNoEngine
 }
 
 // Info returns information about the docker server

--- a/testing/containers.go
+++ b/testing/containers.go
@@ -3,7 +3,7 @@ package testing
 import (
 	"testing"
 
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
 	"github.com/libkermit/docker"
 )
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -8,7 +8,7 @@ package testing
 import (
 	"testing"
 
-	"github.com/docker/engine-api/client"
+	"github.com/docker/docker/client"
 	"github.com/libkermit/docker"
 )
 

--- a/trash.yml
+++ b/trash.yml
@@ -1,17 +1,19 @@
 package: github.com/libkermit/docker
 
 import:
+- package: github.com/docker/docker
+  version: 17aaa0890a7f53cbd9c8806a93de73898ea92813
 - package: github.com/docker/distribution
-  version: 5bbf65499960b184fe8e0f045397375e1a6722b8
-- package: github.com/docker/engine-api
-  version: 62043eb79d581a32ea849645277023c550732e52
+  version: fbb70dc3a14ca65cdac3aaf5e5122b03b42f6fbc
 - package: github.com/docker/go-connections
-  version: 990a1a1a70b0da4c4cb70e117971a4f0babfbf1a
+  version: 1494b6df4050e60923d68cd8cc6a19e7af9f1c01
 - package: github.com/docker/go-units
-  version: f2d77a61e3c169b43402a0a1e84f06daf29b8190
+  version: 8a7beacffa3009a9ac66bad506b18ffdd110cf97
 - package: golang.org/x/net
   version: 4876518f9e71663000c348837735820161a42df7
 - package: github.com/opencontainers/runc
-  version: cc29e3dded8e27ba8f65738f40d251c885030a28
+  version: 02f8fa7863dd3f82909a73e2061897828460d52f
 - package: github.com/Sirupsen/logrus
   version: v0.10.0
+- package: github.com/pkg/errors
+  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302


### PR DESCRIPTION
engine-api is no more, rewrite imports (and deps) using docker/docker.

Signed-off-by: Vincent Demeester vincent@sbr.pm
